### PR TITLE
clean import ignore root transform by default

### DIFF
--- a/utilities/import/mexximpCleanImport.m
+++ b/utilities/import/mexximpCleanImport.m
@@ -28,7 +28,7 @@ function [scene, elements, postFlags] = mexximpCleanImport(sceneFile, varargin)
 parser = inputParser();
 parser.KeepUnmatched = true;
 parser.addRequired('sceneFile', @ischar);
-parser.addParameter('ignoreRootTransform', false, @islogical);
+parser.addParameter('ignoreRootTransform', true, @islogical);
 parser.addParameter('toReplace', {}, @iscellstr);
 parser.addParameter('targetFormat', 'png', @ischar);
 parser.addParameter('exrtoolsImage', 'ninjaben/exrtools-docker', @ischar);


### PR DESCRIPTION
Changes the default behavior of `mexximpCleanImport` to ignore the root node transform, by default.

This is usually what works.  I can't remember a case where it doesn't work.

Would close #1 .